### PR TITLE
Report git branch when reaction -v

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -57,6 +57,10 @@ initialize(() => {
 
       if (versions.reaction) {
         Log.info(`Reaction: ${Log.magenta(versions.reaction)}`);
+
+        if (versions.branchName) {
+          Log.info(`Reaction Branch: ${Log.magenta(versions.branchName)}`);
+        }
       }
 
       return '';

--- a/src/main.js
+++ b/src/main.js
@@ -58,8 +58,8 @@ initialize(() => {
       if (versions.reaction) {
         Log.info(`Reaction: ${Log.magenta(versions.reaction)}`);
 
-        if (versions.branchName) {
-          Log.info(`Reaction Branch: ${Log.magenta(versions.branchName)}`);
+        if (versions.reactionBranch) {
+          Log.info(`Reaction Branch: ${Log.magenta(versions.reactionBranch)}`);
         }
       }
 

--- a/src/utils/versions.js
+++ b/src/utils/versions.js
@@ -31,8 +31,8 @@ export default function () {
   versions.docker = dockerVer ? dockerVer.substring(0, dockerVer.indexOf(',')) : null;
 
   // get Reaction git branch name
-  const branchName = exec('git rev-parse --abbrev-ref HEAD', { silent: true }).stdout.replace(/\r?\n|\r/g, '');
-  versions.branchName = branchName.indexOf('fatal') === -1 ? branchName : null;
+  const reactionBranch = exec('git rev-parse --abbrev-ref HEAD', { silent: true }).stdout.replace(/\r?\n|\r/g, '');
+  versions.reactionBranch = reactionBranch.indexOf('fatal') === -1 ? reactionBranch : null;
 
   // get reaction-cli version
   versions.cli = require('../../package.json').version;

--- a/src/utils/versions.js
+++ b/src/utils/versions.js
@@ -1,7 +1,6 @@
 import fs from 'fs';
 import os from 'os';
 import { exec } from 'shelljs';
-import Log from './logger';
 
 
 export default function () {
@@ -32,7 +31,7 @@ export default function () {
   versions.docker = dockerVer ? dockerVer.substring(0, dockerVer.indexOf(',')) : null;
 
   // get Reaction git branch name
-  const branchName = exec('git rev-parse --abbrev-ref HEAD', { silent: true });
+  const branchName = exec('git rev-parse --abbrev-ref HEAD', { silent: true }).stdout.replace(/\r?\n|\r/g, '');
   versions.branchName = branchName.indexOf('fatal') === -1 ? branchName : null;
 
   // get reaction-cli version

--- a/src/utils/versions.js
+++ b/src/utils/versions.js
@@ -31,6 +31,10 @@ export default function () {
   const dockerVer = exec('docker -v', { silent: true }).stdout.replace(/Docker version /g, '');
   versions.docker = dockerVer ? dockerVer.substring(0, dockerVer.indexOf(',')) : null;
 
+  // get Reaction git branch name
+  const branchName = exec('git rev-parse --abbrev-ref HEAD', { silent: true });
+  versions.branchName = branchName.indexOf('fatal') === -1 ? branchName : null;
+
   // get reaction-cli version
   versions.cli = require('../../package.json').version;
 


### PR DESCRIPTION
During a discussion yesterday, it was brought up that knowing the branch name is often important for debugging community issues. This PR adds the git branch name to the `reaction -v` output.
![image](https://cloud.githubusercontent.com/assets/1203639/24716555/491904bc-19e4-11e7-8355-1f0e23444d62.png)
