### PR TITLE
Add a new build step : "Asset provisioning"

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chalk": "2.3.0",
     "cli-table2": "0.2.0",
     "command-exists": "1.2.2",
-    "fs-extra": "4.0.2",
+    "fs-extra": "^4.0.2",
     "inquirer": "3.3.0",
     "keypair": "1.0.1",
     "latest-semver": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "chalk": "2.3.0",
     "cli-table2": "0.2.0",
     "command-exists": "1.2.2",
-    "fs-extra": "^4.0.2",
+    "fs-extra": "4.0.2",
     "inquirer": "3.3.0",
     "keypair": "1.0.1",
     "latest-semver": "1.0.0",

--- a/src/commands/plugins.js
+++ b/src/commands/plugins.js
@@ -1,7 +1,7 @@
 import fs from 'fs-extra';
 import path from 'path';
 import { execSync as exec } from 'child_process';
-import { exists, Log, loadPlugins, loadStyles } from '../utils';
+import { exists, Log, loadPlugins, loadStyles, provisionAssets } from '../utils';
 
 const helpMessage = `
 Usage:
@@ -30,6 +30,8 @@ export function plugins(yargs) {
     loadPlugins();
     Log.info('\nSetting up style imports...\n');
     loadStyles();
+    Log.info('\nProvisioning assets...\n');
+    provisionAssets();
     return Log.success('Done!\n');
   }
 

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -64,6 +64,7 @@ export async function run(yargs) {
   Log.info('Setting up style imports...\n');
   loadStyles();
 
+  Log.info('Provisioning assets...\n');
   provisionAssets();
 
   try {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import { execSync as exec } from 'child_process';
-import { Log, exists, loadPlugins, loadStyles, checkForReactionUpdate, setRegistryEnv } from '../utils';
+import { Log, exists, loadPlugins, loadStyles, checkForReactionUpdate, setRegistryEnv, provisionAssets } from '../utils';
 
 export async function run(yargs) {
   Log.args(yargs.argv);
@@ -63,6 +63,8 @@ export async function run(yargs) {
 
   Log.info('Setting up style imports...\n');
   loadStyles();
+
+  provisionAssets();
 
   try {
     exec(cmd, { stdio: 'inherit' });

--- a/src/utils/asset-provisioner.js
+++ b/src/utils/asset-provisioner.js
@@ -63,8 +63,6 @@ function cleanup(appRoot) {
 }
 
 export default function () {
-  Log.info('Provisioning assets...\n');
-
   const appRoot = path.resolve('.').split('.meteor')[0];
   cleanup(appRoot);
 

--- a/src/utils/asset-provisioner.js
+++ b/src/utils/asset-provisioner.js
@@ -1,6 +1,5 @@
-import fs from 'fs-extra';
+import fs  from 'fs-extra'
 import path from 'path';
-import rimraf from 'rimraf';
 import { default as vm } from 'vm';
 import Log from './logger';
 import { exists, getDirectories } from './fs';
@@ -8,24 +7,23 @@ import { exists, getDirectories } from './fs';
 /**
  * getAssetPaths: Get pathnames of all asset directories from each plugin.
  * @param {String} appRoot - absolute path to project root
- * @param {String} subDir - plugin sub-directory (core/included/custom)
+ * @param {String} pluginRoot - path to a plugins sub-directory (core/included/custom)
  * @return {Array} - Array of objects that contain absolute source & destination paths for copy process
  */
-function getAssetPaths(appRoot, subDir) {
+function getAssetPaths(appRoot, pluginRoot) {
   const assetPaths = [];
-  const pluginRoot = path.join(appRoot, '/imports/plugins/', subDir);
   // get all plugin directories at provided base path
   const pluginDirs = getDirectories(pluginRoot);
   pluginDirs.forEach((pluginDir) => {
     const pluginPath = pluginRoot + pluginDir;
     const registryImport = pluginPath + '/register.js';
-    let pluginName = ''; // this is where the result of register.js execution goes into.
+    let pluginName = ""; // this is where the result of register.js execution goes into.
     if (exists(registryImport)) {
       try {
-        const content = fs.readFileSync(registryImport, 'utf8');
+        const content = fs.readFileSync(registryImport, "utf8");
         if (content  && content.length) {
           // Strip out all import statements.
-          const code = content.replace(/import.*\n/g, '');
+          const code = content.replace(/import.*\n/g, "");
           const sandbox = {
             // Mock Reaction.registerPackage function
             Reaction: {
@@ -43,8 +41,8 @@ function getAssetPaths(appRoot, subDir) {
           vm.createContext(sandbox);
           vm.runInContext(code, sandbox);
         }
-      } catch (error) {
-        Log.error(`Can't execute file ${registryImport}: ${error}`);
+      } catch (err) {
+        Log.error(`Can't execute file ${registryImport}: ${err}`);
         process.exit(1);
       }
 
@@ -53,14 +51,14 @@ function getAssetPaths(appRoot, subDir) {
         if (exists(privateResourcesDirectory)) {
           assetPaths.push({
             source: privateResourcesDirectory,
-            destination: path.join(appRoot, 'private/plugins', pluginName)
+            destination: path.join(appRoot, "private/plugins", pluginName)
           });
         }
         const publicResourcesDirectory = pluginPath + '/public';
         if (exists(publicResourcesDirectory)) {
           assetPaths.push({
             source: publicResourcesDirectory,
-            destination: path.join(appRoot, 'public/plugins', pluginName)
+            destination: path.join(appRoot, "public/plugins", pluginName)
           });
         }
       } else {
@@ -73,34 +71,27 @@ function getAssetPaths(appRoot, subDir) {
 
 /**
  * copyAssets: Copy all asset files into application's /private folder
- *
  * @param {Array} assetDirs - Array of objects that contain the absolute source and destination paths for copying the assets.
- * @return {undefined}
+ * @return undefined
  */
-function copyAssets(assetDirs) {
-  for (const { source, destination } of assetDirs) {
-    try {
-      fs.copySync(source, destination);
-    } catch (error) {
-      Log.error(`Can't copy files from ${source} to ${destination}: ${error}`);
-    }
+function copyAssets(assetDirs){
+  for (const {source, destination} of assetDirs) {
+    fs.copySync(source, destination);
   }
-}
-
-function cleanup(appRoot) {
-  rimraf(`${appRoot}/public/plugins/*`);
-  rimraf(`${appRoot}/private/plugins/*`);
 }
 
 export default function () {
   Log.info('Provisioning assets...\n');
 
   const appRoot = path.resolve('.').split('.meteor')[0];
-  cleanup(appRoot);
+  const pluginsPath = path.join(appRoot, '/imports/plugins/');
+  const corePlugins = pluginsPath + 'core/';
+  const includedPlugins = pluginsPath + 'included/';
+  const customPlugins = pluginsPath + 'custom/';
 
-  const core = getAssetPaths(appRoot, 'core');
-  const included = getAssetPaths(appRoot, 'included');
-  const custom = getAssetPaths(appRoot, 'custom');
+  const core = getAssetPaths(appRoot, corePlugins);
+  const included = getAssetPaths(appRoot, includedPlugins);
+  const custom = getAssetPaths(appRoot, customPlugins);
 
   const assetDirs = [].concat(core, included, custom);
   copyAssets(assetDirs);

--- a/src/utils/asset-provisioner.js
+++ b/src/utils/asset-provisioner.js
@@ -1,24 +1,69 @@
 import fs  from 'fs-extra'
 import path from 'path';
+import { default as vm } from 'vm';
 import Log from './logger';
 import { exists, getDirectories } from './fs';
 
-
-
-
 /**
  * getAssetPaths: Get pathnames of all asset directories from each plugin.
- * @param {String} baseDirPath - path to a plugins sub-directory (core/included/custom)
- * @return {Array} - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
+ * @param {String} appRoot - absolute path to project root
+ * @param {String} pluginRoot - path to a plugins sub-directory (core/included/custom)
+ * @return {Array} - Array of objects that contain absolute source & destination paths for copy process
  */
-function getAssetPaths(baseDirPath) {
+function getAssetPaths(appRoot, pluginRoot) {
   const assetPaths = [];
   // get all plugin directories at provided base path
-  const pluginDirs = getDirectories(baseDirPath);
-  pluginDirs.forEach((plugin) => {
-    const assetDirectory = baseDirPath + plugin + '/private';
-    if (exists(assetDirectory)) {
-      assetPaths.push({name: plugin, dir: assetDirectory});
+  const pluginDirs = getDirectories(pluginRoot);
+  pluginDirs.forEach((pluginDir) => {
+    const pluginPath = pluginRoot + pluginDir;
+    const registryImport = pluginPath + '/register.js';
+    let pluginName = ""; // this is where the result of register.js execution goes into.
+    if (exists(registryImport)) {
+      try {
+        const content = fs.readFileSync(registryImport, "utf8");
+        if (content  && content.length) {
+          // Strip out all import statements.
+          const code = content.replace(/import.*\n/g, "");
+          const sandbox = {
+            // Mock Reaction.registerPackage function
+            Reaction: {
+              registerPackage(config) {
+                pluginName = config.name;
+              }
+            },
+            _: {
+              // lodash's extend is still used in a couple of register.js
+              extend() {
+                return Object.assign(...arguments);
+              }
+            }
+          };
+          vm.createContext(sandbox);
+          vm.runInContext(code, sandbox);
+        }
+      } catch (err) {
+        Log.error(`Can't execute file ${registryImport}: ${err}`);
+        process.exit(1);
+      }
+
+      if (pluginName) {
+        const privateResourcesDirectory = pluginPath + '/private';
+        if (exists(privateResourcesDirectory)) {
+          assetPaths.push({
+            source: privateResourcesDirectory,
+            destination: path.join(appRoot, "private/plugins", pluginName)
+          });
+        }
+        const publicResourcesDirectory = pluginPath + '/public';
+        if (exists(publicResourcesDirectory)) {
+          assetPaths.push({
+            source: publicResourcesDirectory,
+            destination: path.join(appRoot, "public/plugins", pluginName)
+          });
+        }
+      } else {
+        Log.info(`Can't determine plugin name for plugin directory ${pluginPath}. No resources copied.`);
+      }
     }
   });
   return assetPaths;
@@ -26,14 +71,12 @@ function getAssetPaths(baseDirPath) {
 
 /**
  * copyAssets: Copy all asset files into application's /private folder
- * @param {String} appRoot - application root path
- * @param {Array} assetDirs - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
+ * @param {Array} assetDirs - Array of objects that contain the absolute source and destination paths for copying the assets.
  * @return undefined
  */
-function copyAssets(appRoot, assetDirs){
-  for (const {dir, name} of assetDirs) {
-    const targetDir = path.join(appRoot, "private/plugins", name);
-    fs.copySync(dir, targetDir);
+function copyAssets(assetDirs){
+  for (const {source, destination} of assetDirs) {
+    fs.copySync(source, destination);
   }
 }
 
@@ -46,10 +89,10 @@ export default function () {
   const includedPlugins = pluginsPath + 'included/';
   const customPlugins = pluginsPath + 'custom/';
 
-  const core = getAssetPaths(corePlugins);
-  const included = getAssetPaths(includedPlugins);
-  const custom = getAssetPaths(customPlugins);
+  const core = getAssetPaths(appRoot, corePlugins);
+  const included = getAssetPaths(appRoot, includedPlugins);
+  const custom = getAssetPaths(appRoot, customPlugins);
 
   const assetDirs = [].concat(core, included, custom);
-  copyAssets(appRoot, assetDirs);
+  copyAssets(assetDirs);
 }

--- a/src/utils/asset-provisioner.js
+++ b/src/utils/asset-provisioner.js
@@ -1,69 +1,24 @@
 import fs  from 'fs-extra'
 import path from 'path';
-import { default as vm } from 'vm';
 import Log from './logger';
 import { exists, getDirectories } from './fs';
 
+
+
+
 /**
  * getAssetPaths: Get pathnames of all asset directories from each plugin.
- * @param {String} appRoot - absolute path to project root
- * @param {String} pluginRoot - path to a plugins sub-directory (core/included/custom)
- * @return {Array} - Array of objects that contain absolute source & destination paths for copy process
+ * @param {String} baseDirPath - path to a plugins sub-directory (core/included/custom)
+ * @return {Array} - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
  */
-function getAssetPaths(appRoot, pluginRoot) {
+function getAssetPaths(baseDirPath) {
   const assetPaths = [];
   // get all plugin directories at provided base path
-  const pluginDirs = getDirectories(pluginRoot);
-  pluginDirs.forEach((pluginDir) => {
-    const pluginPath = pluginRoot + pluginDir;
-    const registryImport = pluginPath + '/register.js';
-    let pluginName = ""; // this is where the result of register.js execution goes into.
-    if (exists(registryImport)) {
-      try {
-        const content = fs.readFileSync(registryImport, "utf8");
-        if (content  && content.length) {
-          // Strip out all import statements.
-          const code = content.replace(/import.*\n/g, "");
-          const sandbox = {
-            // Mock Reaction.registerPackage function
-            Reaction: {
-              registerPackage(config) {
-                pluginName = config.name;
-              }
-            },
-            _: {
-              // lodash's extend is still used in a couple of register.js
-              extend() {
-                return Object.assign(...arguments);
-              }
-            }
-          };
-          vm.createContext(sandbox);
-          vm.runInContext(code, sandbox);
-        }
-      } catch (err) {
-        Log.error(`Can't execute file ${registryImport}: ${err}`);
-        process.exit(1);
-      }
-
-      if (pluginName) {
-        const privateResourcesDirectory = pluginPath + '/private';
-        if (exists(privateResourcesDirectory)) {
-          assetPaths.push({
-            source: privateResourcesDirectory,
-            destination: path.join(appRoot, "private/plugins", pluginName)
-          });
-        }
-        const publicResourcesDirectory = pluginPath + '/public';
-        if (exists(publicResourcesDirectory)) {
-          assetPaths.push({
-            source: publicResourcesDirectory,
-            destination: path.join(appRoot, "public/plugins", pluginName)
-          });
-        }
-      } else {
-        Log.info(`Can't determine plugin name for plugin directory ${pluginPath}. No resources copied.`);
-      }
+  const pluginDirs = getDirectories(baseDirPath);
+  pluginDirs.forEach((plugin) => {
+    const assetDirectory = baseDirPath + plugin + '/private';
+    if (exists(assetDirectory)) {
+      assetPaths.push({name: plugin, dir: assetDirectory});
     }
   });
   return assetPaths;
@@ -71,12 +26,14 @@ function getAssetPaths(appRoot, pluginRoot) {
 
 /**
  * copyAssets: Copy all asset files into application's /private folder
- * @param {Array} assetDirs - Array of objects that contain the absolute source and destination paths for copying the assets.
+ * @param {String} appRoot - application root path
+ * @param {Array} assetDirs - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
  * @return undefined
  */
-function copyAssets(assetDirs){
-  for (const {source, destination} of assetDirs) {
-    fs.copySync(source, destination);
+function copyAssets(appRoot, assetDirs){
+  for (const {dir, name} of assetDirs) {
+    const targetDir = path.join(appRoot, "private/plugins", name);
+    fs.copySync(dir, targetDir);
   }
 }
 
@@ -89,10 +46,10 @@ export default function () {
   const includedPlugins = pluginsPath + 'included/';
   const customPlugins = pluginsPath + 'custom/';
 
-  const core = getAssetPaths(appRoot, corePlugins);
-  const included = getAssetPaths(appRoot, includedPlugins);
-  const custom = getAssetPaths(appRoot, customPlugins);
+  const core = getAssetPaths(corePlugins);
+  const included = getAssetPaths(includedPlugins);
+  const custom = getAssetPaths(customPlugins);
 
   const assetDirs = [].concat(core, included, custom);
-  copyAssets(assetDirs);
+  copyAssets(appRoot, assetDirs);
 }

--- a/src/utils/asset-provisioner.js
+++ b/src/utils/asset-provisioner.js
@@ -1,0 +1,55 @@
+import fs  from 'fs-extra'
+import path from 'path';
+import Log from './logger';
+import { exists, getDirectories } from './fs';
+
+
+
+
+/**
+ * getAssetPaths: Get pathnames of all asset directories from each plugin.
+ * @param {String} baseDirPath - path to a plugins sub-directory (core/included/custom)
+ * @return {Array} - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
+ */
+function getAssetPaths(baseDirPath) {
+  const assetPaths = [];
+  // get all plugin directories at provided base path
+  const pluginDirs = getDirectories(baseDirPath);
+  pluginDirs.forEach((plugin) => {
+    const assetDirectory = baseDirPath + plugin + '/private';
+    if (exists(assetDirectory)) {
+      assetPaths.push({name: plugin, dir: assetDirectory});
+    }
+  });
+  return assetPaths;
+}
+
+/**
+ * copyAssets: Copy all asset files into application's /private folder
+ * @param {String} appRoot - application root path
+ * @param {Array} assetDirs - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
+ * @return undefined
+ */
+function copyAssets(appRoot, assetDirs){
+  for (const {dir, name} of assetDirs) {
+    const targetDir = path.join(appRoot, "private/plugins", name);
+    fs.copySync(dir, targetDir);
+  }
+}
+
+export default function () {
+  Log.info('Provisioning assets...\n');
+
+  const appRoot = path.resolve('.').split('.meteor')[0];
+  const pluginsPath = path.join(appRoot, '/imports/plugins/');
+  const corePlugins = pluginsPath + 'core/';
+  const includedPlugins = pluginsPath + 'included/';
+  const customPlugins = pluginsPath + 'custom/';
+
+  const core = getAssetPaths(corePlugins);
+  const included = getAssetPaths(includedPlugins);
+  const custom = getAssetPaths(customPlugins);
+
+  const assetDirs = [].concat(core, included, custom);
+  copyAssets(appRoot, assetDirs);
+}

--- a/src/utils/asset-provisioner.js
+++ b/src/utils/asset-provisioner.js
@@ -1,39 +1,64 @@
-import fs  from 'fs-extra'
+import fs  from 'fs-extra';
 import path from 'path';
+import rimraf from 'rimraf';
 import Log from './logger';
 import { exists, getDirectories } from './fs';
 
 
-
-
 /**
  * getAssetPaths: Get pathnames of all asset directories from each plugin.
- * @param {String} baseDirPath - path to a plugins sub-directory (core/included/custom)
- * @return {Array} - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
+ * @param { String } baseDirPath - path to a plugins sub-directory (core/included/custom)
+ * @returns { Array } - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
  */
 function getAssetPaths(baseDirPath) {
   const assetPaths = [];
   // get all plugin directories at provided base path
   const pluginDirs = getDirectories(baseDirPath);
   pluginDirs.forEach((plugin) => {
-    const assetDirectory = baseDirPath + plugin + '/private';
+    const assetDirectory = baseDirPath + plugin;
     if (exists(assetDirectory)) {
-      assetPaths.push({name: plugin, dir: assetDirectory});
+      assetPaths.push({ name: plugin, dir: assetDirectory });
     }
   });
   return assetPaths;
 }
 
 /**
- * copyAssets: Copy all asset files into application's /private folder
- * @param {String} appRoot - application root path
- * @param {Array} assetDirs - Array of objects that contains plugin name & absolutepath of plugins `/private` directory
- * @return undefined
+ * copyAssets: Copy all asset files into application's /private & /public folders
+ * @param { String } appRoot - application root path
+ * @param { Array } assetDirs - Array of objects that contains plugin name & absolutepath of plugin's root directory
+ * @returns { undefined }
  */
-function copyAssets(appRoot, assetDirs){
-  for (const {dir, name} of assetDirs) {
-    const targetDir = path.join(appRoot, "private/plugins", name);
-    fs.copySync(dir, targetDir);
+function copyAssets(appRoot, assetDirs) {
+  for (const { dir, name } of assetDirs) {
+    for (const folder of ['private', 'public']) {
+      const sourceDir = dir + '/' + folder;
+      const targetDir = path.join(appRoot, folder, 'plugins', name);
+      if (exists(sourceDir)) {
+        try {
+          fs.copySync(sourceDir, targetDir);
+        } catch (error) {
+          Log.error(`Can't copy files from ${sourceDir} to ${targetDir}: ${error.message}`);
+        }
+      }
+    }
+  }
+}
+
+/**
+ * cleanup: Removes all (possibly outdated) assets, before copying them from each plugin into
+ * application wide /public and /private folders.
+ * @param { String } appRoot - application root path
+ * @returns { undefined }
+ */
+function cleanup(appRoot) {
+  for (const folder of ['private', 'public']) {
+    const files = `${appRoot}/${folder}/plugins/*`;
+    try {
+      rimraf.sync(files);
+    } catch(error) {
+      Log.error(`Can't delete files in ${files}: ${error.message}`);
+    }
   }
 }
 
@@ -41,6 +66,8 @@ export default function () {
   Log.info('Provisioning assets...\n');
 
   const appRoot = path.resolve('.').split('.meteor')[0];
+  cleanup(appRoot);
+
   const pluginsPath = path.join(appRoot, '/imports/plugins/');
   const corePlugins = pluginsPath + 'core/';
   const includedPlugins = pluginsPath + 'included/';

--- a/src/utils/asset-provisioner.js
+++ b/src/utils/asset-provisioner.js
@@ -1,5 +1,6 @@
-import fs  from 'fs-extra'
+import fs from 'fs-extra';
 import path from 'path';
+import rimraf from 'rimraf';
 import { default as vm } from 'vm';
 import Log from './logger';
 import { exists, getDirectories } from './fs';
@@ -7,23 +8,24 @@ import { exists, getDirectories } from './fs';
 /**
  * getAssetPaths: Get pathnames of all asset directories from each plugin.
  * @param {String} appRoot - absolute path to project root
- * @param {String} pluginRoot - path to a plugins sub-directory (core/included/custom)
+ * @param {String} subDir - plugin sub-directory (core/included/custom)
  * @return {Array} - Array of objects that contain absolute source & destination paths for copy process
  */
-function getAssetPaths(appRoot, pluginRoot) {
+function getAssetPaths(appRoot, subDir) {
   const assetPaths = [];
+  const pluginRoot = path.join(appRoot, '/imports/plugins/', subDir);
   // get all plugin directories at provided base path
   const pluginDirs = getDirectories(pluginRoot);
   pluginDirs.forEach((pluginDir) => {
     const pluginPath = pluginRoot + pluginDir;
     const registryImport = pluginPath + '/register.js';
-    let pluginName = ""; // this is where the result of register.js execution goes into.
+    let pluginName = ''; // this is where the result of register.js execution goes into.
     if (exists(registryImport)) {
       try {
-        const content = fs.readFileSync(registryImport, "utf8");
+        const content = fs.readFileSync(registryImport, 'utf8');
         if (content  && content.length) {
           // Strip out all import statements.
-          const code = content.replace(/import.*\n/g, "");
+          const code = content.replace(/import.*\n/g, '');
           const sandbox = {
             // Mock Reaction.registerPackage function
             Reaction: {
@@ -41,8 +43,8 @@ function getAssetPaths(appRoot, pluginRoot) {
           vm.createContext(sandbox);
           vm.runInContext(code, sandbox);
         }
-      } catch (err) {
-        Log.error(`Can't execute file ${registryImport}: ${err}`);
+      } catch (error) {
+        Log.error(`Can't execute file ${registryImport}: ${error}`);
         process.exit(1);
       }
 
@@ -51,14 +53,14 @@ function getAssetPaths(appRoot, pluginRoot) {
         if (exists(privateResourcesDirectory)) {
           assetPaths.push({
             source: privateResourcesDirectory,
-            destination: path.join(appRoot, "private/plugins", pluginName)
+            destination: path.join(appRoot, 'private/plugins', pluginName)
           });
         }
         const publicResourcesDirectory = pluginPath + '/public';
         if (exists(publicResourcesDirectory)) {
           assetPaths.push({
             source: publicResourcesDirectory,
-            destination: path.join(appRoot, "public/plugins", pluginName)
+            destination: path.join(appRoot, 'public/plugins', pluginName)
           });
         }
       } else {
@@ -71,27 +73,34 @@ function getAssetPaths(appRoot, pluginRoot) {
 
 /**
  * copyAssets: Copy all asset files into application's /private folder
+ *
  * @param {Array} assetDirs - Array of objects that contain the absolute source and destination paths for copying the assets.
- * @return undefined
+ * @return {undefined}
  */
-function copyAssets(assetDirs){
-  for (const {source, destination} of assetDirs) {
-    fs.copySync(source, destination);
+function copyAssets(assetDirs) {
+  for (const { source, destination } of assetDirs) {
+    try {
+      fs.copySync(source, destination);
+    } catch (error) {
+      Log.error(`Can't copy files from ${source} to ${destination}: ${error}`);
+    }
   }
+}
+
+function cleanup(appRoot) {
+  rimraf(`${appRoot}/public/plugins/*`);
+  rimraf(`${appRoot}/private/plugins/*`);
 }
 
 export default function () {
   Log.info('Provisioning assets...\n');
 
   const appRoot = path.resolve('.').split('.meteor')[0];
-  const pluginsPath = path.join(appRoot, '/imports/plugins/');
-  const corePlugins = pluginsPath + 'core/';
-  const includedPlugins = pluginsPath + 'included/';
-  const customPlugins = pluginsPath + 'custom/';
+  cleanup(appRoot);
 
-  const core = getAssetPaths(appRoot, corePlugins);
-  const included = getAssetPaths(appRoot, includedPlugins);
-  const custom = getAssetPaths(appRoot, customPlugins);
+  const core = getAssetPaths(appRoot, 'core');
+  const included = getAssetPaths(appRoot, 'included');
+  const custom = getAssetPaths(appRoot, 'custom');
 
   const assetDirs = [].concat(core, included, custom);
   copyAssets(assetDirs);

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -19,3 +19,4 @@ export { default as loadStyles } from './style-loader';
 export { track } from './analytics';
 export { default as getVersions } from './versions';
 export * from './yarn_check';
+export { default as provisionAssets } from './asset-provisioner';


### PR DESCRIPTION
The idea is that a plugin can hold its own assets in a folder called
/private. During build of the application, the content of this folder is
copied to <application>/private/plugins/<plugin_name>. This seems to me
like a sensible way (the only?) way to actually bundle the assets of the
plugin for usage through Meteor's Assets API.