### PR TITLE
Don't delete README during asset provisioning

### DIFF
--- a/src/utils/asset-provisioner.js
+++ b/src/utils/asset-provisioner.js
@@ -53,7 +53,7 @@ function copyAssets(appRoot, assetDirs) {
  */
 function cleanup(appRoot) {
   for (const folder of ['private', 'public']) {
-    const files = `${appRoot}/${folder}/plugins/*`;
+    const files = `${appRoot}/${folder}/plugins/!(README.md)`;
     try {
       rimraf.sync(files);
     } catch(error) {


### PR DESCRIPTION

Fixes https://github.com/reactioncommerce/reaction/issues/3743 (in main repo)

README.md should not be deleted during build step.