### PR TITLE
chore: remove auto-loading of settings/settings.json file in CLI

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -24,6 +24,11 @@ export async function run(yargs) {
   if (!!commands.length && commands[0] === 'debug') {
     cmd += ' debug';
   }
+  
+  if (args.settings) {
+    Log.info(`\nUsing settings file at ${Log.magenta(args.settings)}\n`);
+    cmd += ` --settings ${args.settings}`;
+  }
 
   _.forEach(_.omit(args, ['settings', 's', 'registry', 'r', 'raw-logs', 'rawLogs']), (val, key) => {
     if (val) {

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -25,20 +25,6 @@ export async function run(yargs) {
     cmd += ' debug';
   }
 
-  const devSettings = 'settings/dev.settings.json';
-  const prodSettings = 'settings/settings.json';
-
-  if (args.settings) {
-    Log.info(`\nUsing settings file at ${Log.magenta(args.settings)}\n`);
-    cmd += ` --settings ${args.settings}`;
-  } else if (exists(prodSettings)) {
-    Log.info(`\nUsing settings file at ${Log.magenta(prodSettings)}\n`);
-    cmd += ` --settings ${prodSettings}`;
-  } else if (exists(devSettings)) {
-    Log.info(`\nUsing settings file at ${Log.magenta(devSettings)}\n`);
-    cmd += ` --settings ${devSettings}`;
-  }
-
   _.forEach(_.omit(args, ['settings', 's', 'registry', 'r', 'raw-logs', 'rawLogs']), (val, key) => {
     if (val) {
       const dash = key.length > 1 ? '--' : '-';


### PR DESCRIPTION
The `CLI` portion of https://github.com/reactioncommerce/reaction/pull/3951

This PR removes the code which auto-loads `settings/settings.json` when Reaction starts, which means auto-loading of meteor settings, via this file, is disabled.

These settings can still be passed in with flags or `ENV` variables in https://github.com/reactioncommerce/reaction