### PR TITLE
Add exception for inspect-brk and inspect arguments

### DIFF
--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -30,7 +30,7 @@ export async function run(yargs) {
     cmd += ` --settings ${args.settings}`;
   }
 
-  _.forEach(_.omit(args, ['settings', 's', 'registry', 'r', 'raw-logs', 'rawLogs']), (val, key) => {
+  _.forEach(_.omit(args, ['settings', 's', 'registry', 'r', 'raw-logs', 'rawLogs', 'inspect-brk', 'inspectBrk']), (val, key) => {
     if (val) {
       const dash = key.length > 1 ? '--' : '-';
       if (val === true) {
@@ -43,6 +43,12 @@ export async function run(yargs) {
 
   if (args.registry) {
     setRegistryEnv(args.registry);
+  }
+
+  if (typeof args['inspect-brk'] === 'string' || typeof args.inspectBrk === 'string') {
+    cmd += ` --inspect-brk=${args['inspect-brk'] ? args['inspect-brk'] : args.inspectBrk}`;
+  } else if (args['inspect-brk'] === true || args.inspectBrk === true) {
+    cmd += ` --inspect-brk`;
   }
 
   cmd += ' --raw-logs';

--- a/src/commands/run.js
+++ b/src/commands/run.js
@@ -30,7 +30,7 @@ export async function run(yargs) {
     cmd += ` --settings ${args.settings}`;
   }
 
-  _.forEach(_.omit(args, ['settings', 's', 'registry', 'r', 'raw-logs', 'rawLogs', 'inspect-brk', 'inspectBrk']), (val, key) => {
+  _.forEach(_.omit(args, ['settings', 's', 'registry', 'r', 'raw-logs', 'rawLogs', 'inspect', 'inspect-brk', 'inspectBrk']), (val, key) => {
     if (val) {
       const dash = key.length > 1 ? '--' : '-';
       if (val === true) {
@@ -45,10 +45,16 @@ export async function run(yargs) {
     setRegistryEnv(args.registry);
   }
 
-  if (typeof args['inspect-brk'] === 'string' || typeof args.inspectBrk === 'string') {
-    cmd += ` --inspect-brk=${args['inspect-brk'] ? args['inspect-brk'] : args.inspectBrk}`;
+  if (typeof args['inspect-brk'] === 'string') {
+    cmd += ` --inspect-brk=${args['inspect-brk']}`;
+  } else if (typeof args.inspectBrk === 'string') {
+    cmd += ` --inspect-brk=${args.inspectBrk}`;
+  } else if (typeof args.inspect === 'string') {
+    cmd += ` --inspect=${args.inspect}`;
   } else if (args['inspect-brk'] === true || args.inspectBrk === true) {
-    cmd += ` --inspect-brk`;
+    cmd += ' --inspect-brk';
+  } else if (args.inspect === true) {
+    cmd += ' --inspect';
   }
 
   cmd += ' --raw-logs';


### PR DESCRIPTION
This is a fix for issue #78. It makes sure that `--inspect-brk` works as expected and doesn't make the app crash on startup.